### PR TITLE
Adopt local OneDev and independent Validator publication policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -250,3 +250,12 @@ examples/quick-start/quick-start.yaml
 .planfile/
 .pyqual/
 .taskill/
+
+# Local ticket worktrees and private recovery state
+/.worktrees/
+/.subactor/leases/
+/.subactor/sessions/
+/.subactor/recovery/
+/.subactor/receipts/
+/.subactor/cache/
+/.subactor/snapshots/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# Repository agent instructions
+
+<!-- wellmanifest:local-ci-publication:start -->
+## Local CI and independent publication
+
+Adopt the publication policy from [Wellmanifest/new-project 0.20.10](https://github.com/wellmanifest/new-project/blob/d5f77d83b3752477cfb95a535d0e1ce77f148576/docs/information/local-ci-publication.md).
+Immutable source revision: `d5f77d83b3752477cfb95a535d0e1ce77f148576`.
+Document SHA-256: `44803480f1d51f64eec81a62335b6725747f01b5f2de78105ebfc4017a7922c6`.
+This is publication-policy adoption; it does not establish full governance,
+adoption of every Wellmanifest pack, deployed CI or successful verification.
+
+For `semcod/*` and `subactor/*`, prefer the protected local OneDev executor
+and independent local Validator App. Preserve the repository's own tests,
+required platform matrix, protected checks and actor boundaries. Read the
+actual protected Validator profile and OneDev configuration; missing profiles
+are coverage gaps. GitHub may host code and PRs without hosting test execution.
+A GitHub Actions billing/capacity failure does not prove local CI is unavailable.
+
+Before publication, observe existing local reconciliation and reuse its receipt.
+Require verification of the exact PR head with the current base and merge result.
+Invoke the trusted local Validator adapter or its existing timer under the
+user's publication authorization; never self-approve or merge directly.
+Use hosted `dispatch-direct-pr.sh` only when the protected deployment explicitly
+selects that transport. This rule supersedes older unconditional hosted-dispatch
+examples, while retaining all additional repository requirements.
+
+Retire a hosted check only after equivalent local tests and the required OS
+matrix have a successful deployed canary and an independently reviewed policy
+migration. Never empty required checks or create synthetic success statuses.
+Report declared, configured, deployed, verified and published evidence separately.
+The complete fleet audit belongs in `subactor/docs/architecture/analysis/local-ci-adoption.md`.
+<!-- wellmanifest:local-ci-publication:end -->

--- a/project/ticket-002/README.md
+++ b/project/ticket-002/README.md
@@ -1,0 +1,11 @@
+# ticket-002: Local CI publication policy
+
+- **Status**: IN_PROGRESS
+- **Workflow state**: EDIT
+
+SESSION_EXECUTION_AUTHORIZATION: user requested implementation and publication across Semcod and Subactor.
+
+AC-01: Pin published policy while preserving custom requirements.
+AC-02: Validate bounded diff and publish through independent protected review.
+
+Allocation: https://github.com/semcod/prefact/issues/2. Canonical fleet evidence: `subactor/docs/architecture/analysis/local-ci-adoption.md`. This ticket does not establish full new-project adoption.

--- a/project/ticket-002/intent.json
+++ b/project/ticket-002/intent.json
@@ -1,0 +1,17 @@
+{
+  "ticket": "ticket-002",
+  "summary": "Adopt immutable local CI publication instructions",
+  "allowedPaths": [
+    "AGENTS.md",
+    ".gitignore",
+    "project/ticket-002/**"
+  ],
+  "forbiddenPaths": [
+    ".env",
+    "config/**",
+    ".github/workflows/**"
+  ],
+  "authorization": "SESSION_EXECUTION_AUTHORIZATION",
+  "standard_revision": "d5f77d83b3752477cfb95a535d0e1ce77f148576",
+  "outcome": "Publication-policy-only adoption with protected review; no executor or required-check mutation."
+}


### PR DESCRIPTION
Older or missing instructions can send publication to hosted Actions even when local verification is available. Adopt the immutable Wellmanifest/new-project 0.20.10 publication policy, preserving existing project rules and protected checks.

This is instructions-only adoption, not a claim of full governance adoption or deployed local CI. Missing OneDev/Validator profiles remain explicit coverage gaps in the canonical fleet audit.

Validation: exact four-file scope (instructions, local recovery ignores and bounded ticket intent), immutable source/digest reference, Worktrees v5 filesystem check, and `git diff --cached --check`. No runtime code, tests, hosted workflows or required checks were changed.

Ticket: ticket-002. Closes https://github.com/semcod/prefact/issues/2. Cross-repository evidence: subactor/docs `architecture/analysis/local-ci-adoption.md`.
